### PR TITLE
Adicionando tipo de input select ao seletor de tipos de input

### DIFF
--- a/src/components/InputType/InputType.tsx
+++ b/src/components/InputType/InputType.tsx
@@ -36,6 +36,7 @@ export function InputType({ onChange }: Props) {
           <option value="textarea">Área de Texto</option>
           <option value="checkbox">Checkbox</option>
           <option value="radio">Radio</option>
+          <option value="select">Select</option>
         </InputTypeSelect>
       )}
     </InputTypeContainer>


### PR DESCRIPTION
O seletor de tipos de input não contava com o tipo select em suas opções. Com essa modificação, a opção para utilizar um campo select foi adicionada.