### PR TITLE
Corrigindo erros de tipo ao importar assets

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Ao importar assets (como imagens ou arquivos .css) para "empacotamento" pelo Vite o linter do TypeScript acusa um erro na importação do "módulo" relacionado à ausência de uma definição de tipo para esses arquivos. Nesse commit, foi feita uma modificação na configuração do compilador TypeScript para incluir as definições de tipo do Vite e, assim, eliminar esse problema.