### PR TITLE
Corrigindo atribuição do nome/valor no checkbox

### DIFF
--- a/packages/client/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/packages/client/src/components/CheckboxInput/CheckboxInput.tsx
@@ -29,7 +29,7 @@ export function CheckboxInput({
         disabled={disabled}
         {...register(name, { required: required })}
       />
-      <CheckboxLabel htmlFor={name}>{value}</CheckboxLabel>
+      <CheckboxLabel htmlFor={value}>{name}</CheckboxLabel>
     </CheckboxContainer>
   )
 }


### PR DESCRIPTION
A atribuição do nome/valor nas opções do checkbox estava trocada, de modo que o valor era mostrado na interface e o nome era utilizado no backend, enquanto deveria ser o contrário. Esse PR contém um commit que corrige esse erro, identificado durante a criação da página de visualização do formulário.